### PR TITLE
use visor Dockerfile for provenanceio/node:${{ matrix.net }} images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -46,6 +46,6 @@ jobs:
           build-args: |
             CHAIN_ID=${{ matrix.net }}
           platforms: linux/amd64
-          file: docker/node/archive/Dockerfile
+          file: docker/node/visor/Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
           tags: provenanceio/node:${{ matrix.net }}


### PR DESCRIPTION
Use `docker/node/visor/Dockerfile` to build visor images.

Possible fix for: https://github.com/provenance-io/testnet/issues/18