### PR TITLE
Removed persistent peers from configuration

### DIFF
--- a/pio-testnet-1/config.toml
+++ b/pio-testnet-1/config.toml
@@ -184,7 +184,7 @@ external_address = ""
 seeds = ""
 
 # Comma separated list of nodes to keep persistent connections to
-persistent_peers = "26240dd8c5f78c3c54196613b9c04d2d750a534e@35.232.121.26:26656,8fcbbdba4088a604d6c083dd6be19e070adc1d93@35.194.76.143:26656,1f159852f00292803d8c937d953cb3da68a25624@34.75.172.89:26656,7970256f3f8879e0152bb26e977d2139890cb59d@34.82.40.187:26656"
+persistent_peers = ""
 
 # UPNP port forwarding
 upnp = false

--- a/pio-testnet-1/config.toml
+++ b/pio-testnet-1/config.toml
@@ -181,7 +181,7 @@ laddr = "tcp://0.0.0.0:26656"
 external_address = ""
 
 # Comma separated list of seed nodes to connect to
-seeds = ""
+seeds = "2de841ce706e9b8cdff9af4f137e52a4de0a85b2@seed-0.test.provenance.io:26656,add1d50d00c8ff79a6f7b9873cc0d9d20622614e@seed-1.test.provenance.io:26656"
 
 # Comma separated list of nodes to keep persistent connections to
 persistent_peers = ""

--- a/pio-testnet-1/node-config.toml
+++ b/pio-testnet-1/node-config.toml
@@ -181,10 +181,10 @@ laddr = "tcp://0.0.0.0:26656"
 external_address = ""
 
 # Comma separated list of seed nodes to connect to
-seeds = "2de841ce706e9b8cdff9af4f137e52a4de0a85b2@104.196.26.176:26656,add1d50d00c8ff79a6f7b9873cc0d9d20622614e@34.71.242.51:26656"
+seeds = "2de841ce706e9b8cdff9af4f137e52a4de0a85b2@seed-0.test.provenance.io:26656,add1d50d00c8ff79a6f7b9873cc0d9d20622614e@seed-1.test.provenance.io:26656"
 
 # Comma separated list of nodes to keep persistent connections to
-persistent_peers = "26240dd8c5f78c3c54196613b9c04d2d750a534e@35.232.121.26:26656,8fcbbdba4088a604d6c083dd6be19e070adc1d93@35.194.76.143:26656,1f159852f00292803d8c937d953cb3da68a25624@34.75.172.89:26656,7970256f3f8879e0152bb26e977d2139890cb59d@34.82.40.187:26656"
+persistent_peers = ""
 
 # UPNP port forwarding
 upnp = false


### PR DESCRIPTION
We are now relying on seed nodes and the community network for peering connections, no connections should be made specifically to these nodes going forward